### PR TITLE
Fix: Improve mobile layout and initial page scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
         <div class="c">
             <div x-show="!bookingConfirmed">
                 <div class="sec-head tc booking-section-head">
-                    <h2 class="bil-parent-spread" x-ref="bookingSectionTitle" tabindex="-1">
+                    <h2 class="bil-parent-spread" x-ref="bookingSectionTitle">
                         <span class="en">Book Your Udheya</span><span class="ar">احجز أضحيتك</span>
                     </h2>
                 </div>
@@ -267,7 +267,7 @@
                             </div>
 
                             <div id="step1-content" class="form-step-content">
-                                <div class="sec-head"><h2 class="bil-parent-spread" x-ref="step1Title" tabindex="-1"><span class="en">Select Animal & Weight *</span><span class="ar">اختر الحيوان والوزن *</span></h2></div>
+                                <div class="sec-head"><h2 class="bil-parent-spread" x-ref="step1Title"><span class="en">Select Animal & Weight *</span><span class="ar">اختر الحيوان والوزن *</span></h2></div>
                                 <div class="livestock-sharia-note bil-row">
                                     <p class="en">All animals meet Sharia age/health requirements for Udheya.</p><p class="ar">جميع الحيوانات تستوفي متطلبات الشريعة للعمر والصحة للأضحية.</p>
                                 </div>

--- a/script.js
+++ b/script.js
@@ -84,7 +84,7 @@ document.addEventListener('alpine:init', () => {
                     if (this.productOptions.livestock?.length > 0) this.updateAllDisplayedPrices();
                     else if (!this.apiError) this.userFriendlyApiError = this.userFriendlyApiError || "Livestock options could not be loaded.";
                     this.updateAllStepCompletionStates(); this.handleScroll();
-                    this.focusOnRef(this.bookingConfirmed ? "bookingConfirmedTitle" : (this.$refs.step1Title ? "step1Title" : "bookingSectionTitle"));
+                    this.focusOnRef(this.bookingConfirmed ? "bookingConfirmedTitle" : "body", false);
                     this.isLoading.init = false;
                 });
             }

--- a/styles.css
+++ b/styles.css
@@ -295,34 +295,34 @@ html[lang=ar] .form-error-msg,body:has([dir=rtl]) .form-error-msg,.form-error-ms
 .pban-text-content .bil-row>.en{margin-bottom:var(--s1)}
 .compact-how-it-works .how-it-works-grid{grid-template-columns:repeat(auto-fit,minmax(160px,1fr))}
 
-.bil-keep-side-by-side-mobile {
-    flex-direction: row !important; /* Override column direction for bil-parent-spread */
-    flex-wrap: nowrap !important; /* Prevent wrapping for bil-row */
-}
+/*.bil-keep-side-by-side-mobile {*/
+/*    flex-direction: row !important; /* Override column direction for bil-parent-spread */*/
+/*    flex-wrap: nowrap !important; /* Prevent wrapping for bil-row */*/
+/*}*/
 
-.bil-keep-side-by-side-mobile > .en,
-.bil-keep-side-by-side-mobile > p.en {
-    flex-basis: 48% !important; /* Restore side-by-side behavior */
-    text-align: left !important;
-    margin-bottom: 0 !important; /* Remove bottom margin if it was added for stacking */
-}
+/*.bil-keep-side-by-side-mobile > .en,*/
+/*.bil-keep-side-by-side-mobile > p.en {*/
+/*    flex-basis: 48% !important; /* Restore side-by-side behavior */*/
+/*    text-align: left !important;*/
+/*    margin-bottom: 0 !important; /* Remove bottom margin if it was added for stacking */*/
+/*}*/
 
-.bil-keep-side-by-side-mobile > .ar,
-.bil-keep-side-by-side-mobile > p.ar {
-    flex-basis: 48% !important; /* Restore side-by-side behavior */
-    text-align: right !important;
-    margin-bottom: 0 !important; /* Remove bottom margin if it was added for stacking */
-}
+/*.bil-keep-side-by-side-mobile > .ar,*/
+/*.bil-keep-side-by-side-mobile > p.ar {*/
+/*    flex-basis: 48% !important; /* Restore side-by-side behavior */*/
+/*    text-align: right !important;*/
+/*    margin-bottom: 0 !important; /* Remove bottom margin if it was added for stacking */*/
+/*}*/
 
 /* Specifically for .bil-parent-spread elements that get .bil-keep-side-by-side-mobile */
-.bil-parent-spread.bil-keep-side-by-side-mobile > .en {
-    margin-right: auto !important; /* Restore original margin */
-    text-align: left !important;
-}
-.bil-parent-spread.bil-keep-side-by-side-mobile > .ar {
-    margin-left: auto !important; /* Restore original margin */
-    text-align: right !important;
-}
+/*.bil-parent-spread.bil-keep-side-by-side-mobile > .en {*/
+/*    margin-right: auto !important; /* Restore original margin */*/
+/*    text-align: left !important;*/
+/*}*/
+/*.bil-parent-spread.bil-keep-side-by-side-mobile > .ar {*/
+/*    margin-left: auto !important; /* Restore original margin */*/
+/*    text-align: right !important;*/
+/*}*/
 }
 @media(max-width:768px){html{font-size:14px}
 body{padding-top:var(--header-height)}
@@ -361,7 +361,7 @@ body{padding-top:var(--header-height)}
 .brand-logo{margin-right:0;margin-bottom:0;text-align:left;justify-content:flex-start}
 .main-nav.desktop-nav,.header-extras.desktop-extras{display:none}
 .hamburger-btn{display:inline-flex;align-items:center;justify-content:center}
-.hero-section h1{font-size:1.6rem}.hero-section h2{font-size:1.1rem}.hero-section p{font-size:.9rem}
+.hero-section h1{font-size:1.4rem}.hero-section h2{font-size:1.1rem}.hero-section p{font-size:.9rem}
 .pm label{min-height:50px} /* Ensure consistency with desktop .pm label height */
 .pmeths .payment-icon{height:28px} /* Ensure consistency with desktop icon height */
 .footer-payment-icon{height:24px} /* Ensure consistency for footer icons on mobile */


### PR DESCRIPTION
- Modifies CSS to ensure hero section text stacks correctly on mobile devices (screen widths <= 991px) by removing rules that forced side-by-side layout. This provides a more consistent reading experience for bilingual content on smaller screens.
- Adjusts JavaScript initialization to prevent the page from automatically scrolling down to the booking form on load. The initial focus is now set without causing a scroll, allowing you to see the top of the page first.
- Removes unnecessary `tabindex` attributes from heading elements that were previously part of the auto-scroll behavior.
- Confirmed hero section H1 font size is adjusted for mobile for better readability when stacked.

These changes address your feedback regarding inconsistent text layout on mobile and the page skipping the hero section on initial load.