### PR TITLE
Make setup.html buttons more compact to match main site

### DIFF
--- a/public/setup.html
+++ b/public/setup.html
@@ -10,7 +10,7 @@
         h1{color:#2C5F41;border-bottom:2px solid #D2B48C;padding-bottom:4px;margin:0 0 10px 0;font-size:1.3em;text-align:center}
         p{font-size:.85rem;margin:0 0 .5rem 0;line-height:1.3} 
         .warn{color:#dc3545;font-weight:bold;background:#ffe6e6;padding:10px;border-radius:6px;border-left:3px solid #dc3545}
-        button{padding:8px 16px;background:#2C5F41;color:white;border:0;border-radius:6px;cursor:pointer;font-size:.9rem;margin:5px;font-weight:600;transition:all 0.3s ease}
+        button{padding:5px 12px;background:#2C5F41;color:white;border:0;border-radius:6px;cursor:pointer;font-size:.8rem;margin:4px;font-weight:600;transition:all 0.3s ease;min-height:28px}
         button:disabled{background:#ccc;cursor:not-allowed} 
         button:hover:not(:disabled){background:#1A3B2B;transform:translateY(-1px);box-shadow:0 3px 10px rgba(0,0,0,0.15)}
         #out{margin-top:8px;padding:8px;background:#1a1a1a;color:#e0e0e0;border-radius:4px;font-family:'Courier New',monospace;font-size:9px;line-height:1.3;max-height:60vh;overflow-y:auto;border:1px solid #444}
@@ -42,11 +42,11 @@
         <div style="display:flex;gap:8px;margin:8px 0">
             <div style="flex:1">
                 <label style="display:block;margin-bottom:3px;font-weight:bold;font-size:11px">Collections JSON:</label>
-                <textarea id="collectionsData" style="width:100%;height:120px;padding:4px;border:1px solid #ccc;border-radius:3px;font-family:monospace;font-size:9px;line-height:1.2"></textarea>
+                <textarea id="collectionsData" style="width:100%;height:100px;padding:4px;border:1px solid #ccc;border-radius:3px;font-family:monospace;font-size:9px;line-height:1.2"></textarea>
             </div>
             <div style="flex:1">
                 <label style="display:block;margin-bottom:3px;font-weight:bold;font-size:11px">Seed Data JSON:</label>
-                <textarea id="seedData" style="width:100%;height:120px;padding:4px;border:1px solid #ccc;border-radius:3px;font-family:monospace;font-size:9px;line-height:1.2"></textarea>
+                <textarea id="seedData" style="width:100%;height:100px;padding:4px;border:1px solid #ccc;border-radius:3px;font-family:monospace;font-size:9px;line-height:1.2"></textarea>
             </div>
         </div>
         


### PR DESCRIPTION
- Reduce button padding from 8px 16px to 5px 12px
- Decrease font size from 0.9rem to 0.8rem
- Set min-height to 28px for consistency
- Reduce textarea heights from 120px to 100px
- Smaller margins between buttons (4px instead of 5px)

🤖 Generated with [Claude Code](https://claude.ai/code)